### PR TITLE
Create package.json to prepare for publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "thelounge-theme-neuron",
+  "version": "1.0.0",
+  "description": "Dark, minimalist, type-focused theme for The Lounge",
+  "main": "package.json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/easymac/lounge-neuron.git"
+  },
+  "keywords": [
+    "thelounge",
+    "thelounge-theme"
+  ],
+  "author": "easymac",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/easymac/lounge-neuron/issues"
+  },
+  "homepage": "https://github.com/easymac/lounge-neuron#readme",
+  "thelounge": {
+    "css": "neuron.css",
+    "name": "Neuron",
+    "type": "theme"
+  }
+}


### PR DESCRIPTION
This file was created by running `npm init` and following steps listed at https://thelounge.github.io/docs/plugins/themes.html.

Once this theme is published on npm, it can be installed on The Lounge (as of [v2.5.0](https://github.com/thelounge/lounge/releases/tag/v2.5.0)) using the `lounge install` command.